### PR TITLE
Add “check mode” to detect changes to be made

### DIFF
--- a/pazel/app.py
+++ b/pazel/app.py
@@ -136,12 +136,12 @@ def main():
     if not args.check:
         print('Generated BUILD files for %s:' % args.input_path)
         for key, val in checks.items():
-            print(key)
+            print('//%s' % key)
     else:
         if len(checks) > 0:
             print('Would modify the following BUILD files for %s:' % args.input_path)
             for key, val in checks.items():
-                print(key)
+                print('//%s' % key)
                 for line in val:
                     print(line)
             exit(1)

--- a/pazel/bazel_rules.py
+++ b/pazel/bazel_rules.py
@@ -25,8 +25,8 @@ PY_LIBRARY_TEMPLATE = """py_library(
 
 PY_TEST_TEMPLATE = """py_test(
     name = "{name}",
-    srcs = ["{name}.py"],
     size = "{size}",
+    srcs = ["{name}.py"],
     {data}
     {deps}
 )"""

--- a/pazel/generate_rule.py
+++ b/pazel/generate_rule.py
@@ -120,7 +120,13 @@ def generate_rule(script_path, template, package_names, module_names, data_deps,
 
             # Replace the last slash with :.
             last_slash_idx = module_name.rfind('/')
-            module_name = module_name[:last_slash_idx] + ':' + module_name[last_slash_idx + 1:]
+            path = module_name[:last_slash_idx]
+            path_parts = path.split('/')
+            target = module_name[last_slash_idx + 1:]
+            if path_parts[-1] != target:
+                module_name = path + ':' + target
+            else:
+                module_name = path
 
         if multiple_deps:
             deps += 2*tab

--- a/pazel/output_build.py
+++ b/pazel/output_build.py
@@ -91,14 +91,18 @@ def output_build_file(build_source, ignored_rules, output_extension, custom_baze
     # Remove extra newline at end of file.
     output = re.sub('\n\n$', '\n', output)
 
-    with open(build_file_path, 'r') as build_file:
-        original_build_source = build_file.read()
-        diff = unified_diff(original_build_source.splitlines(), output.splitlines())
-        diff_lines = []
-        for line in diff:
-            diff_lines.append(line)
-        if len(diff_lines) > 0:
-            checks[build_file_path] = diff_lines
+    try:
+        with open(build_file_path, 'r') as build_file:
+            original_build_source = build_file.read()
+    except FileNotFoundError:
+        original_build_source = ''
+
+    diff = unified_diff(original_build_source.splitlines(), output.splitlines())
+    diff_lines = []
+    for line in diff:
+        diff_lines.append(line)
+    if len(diff_lines) > 0:
+        checks[build_file_path] = diff_lines
 
     if update:
         with open(build_file_path, 'w') as build_file:

--- a/pazel/tests/test_bazel_rules.py
+++ b/pazel/tests/test_bazel_rules.py
@@ -70,8 +70,8 @@ class TestTemplates(unittest.TestCase):
 
         expected = """py_test(
     name = "my_test",
-    srcs = ["my_test.py"],
     size = "medium",
+    srcs = ["my_test.py"],
     data = ["something"],
     deps = ['//foo:bar']
 )"""
@@ -221,13 +221,13 @@ class TestBazelRuleInference(unittest.TestCase):
         custom_rules = []
 
         self.assertEqual(infer_bazel_rule_type(script_name, binary_with_main_source, custom_rules),
-                         PyBinaryRule)
+                         [PyBinaryRule])
         self.assertEqual(infer_bazel_rule_type(script_name, binary_without_main_source,
-                                               custom_rules), PyBinaryRule)
+                                               custom_rules), [PyBinaryRule])
         self.assertEqual(infer_bazel_rule_type(script_name, module_source, custom_rules),
-                         PyLibraryRule)
+                         [PyLibraryRule])
         self.assertEqual(infer_bazel_rule_type(test_script_name, test_source, custom_rules),
-                         PyTestRule)
+                         [PyTestRule])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* This compiles a list of files to be created and changed along with
a unified diff of the changes.
* If check mode is on, the files and diffs will be printed to stdout and
exit code will be 1.
* Otherwise, functions as normal
* Fixes unit tests
* Output should now match buildifier as well.