### PR TITLE
Feat: [TECH-12663] add a condition for default requirement load

### DIFF
--- a/pazel/output_build.py
+++ b/pazel/output_build.py
@@ -48,8 +48,9 @@ def output_build_file(build_source, ignored_rules, output_extension, custom_baze
     ignored_source = '\n'.join(remaining_ignored_rules)
 
     if any(['requirement("' in source for source in (build_source, ignored_source)]):
-        in_ignored_load_statements = any(['requirement("' in statement for statement in
-                                          ignored_load_statements])
+        in_ignored_load_statements = any(
+            ['requirement("' in statement for statement in ignored_load_statements]
+        ) or any([', "requirement"' in statement for statement in ignored_load_statements])
 
         if not in_ignored_load_statements:
             header += _append_newline(requirement_load)

--- a/pazel/tests/BUILD
+++ b/pazel/tests/BUILD
@@ -40,3 +40,13 @@ py_test(
     size = "small",
     deps = ["//pazel:pazel_extensions"],
 )
+
+py_test(
+    name = "test_output_build",
+    srcs = ["test_output_build.py"],
+    size = "small",
+    deps = [
+        "//pazel:pazel_extensions", 
+        "//pazel:output_build"
+    ],
+)

--- a/pazel/tests/test_output_build.py
+++ b/pazel/tests/test_output_build.py
@@ -1,0 +1,151 @@
+"""Test output build functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from unittest.mock import patch, mock_open
+
+from pazel.output_build import output_build_file
+from pazel.pazel_extensions import OutputExtension
+
+
+class OutputBuildTestCase(unittest.TestCase):
+    """Test output build functions."""
+
+    def setUp(self):
+        self.build_file_path = "urbancompass/src/python3/uc/aws/BUILD"
+        self.build_source = """
+py_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+)
+
+py_library(
+    name = "assume_role",
+    srcs = ["assume_role.py"],
+    deps = [
+        requirement("boto3"),
+        requirement("botocore"),
+    ],
+)"""
+        self.requirement_load = 'load("@py3_deps//:requirements.bzl", "requirement")'
+        self.checks = {}
+        self.update = True
+        self.custom_bazel_rules = []
+        self.output_extension = OutputExtension(
+            header="",
+            footer="",
+        )
+
+    @patch("pazel.output_build.open", new_callable=mock_open, read_data="")
+    def test_output_build_file_with_macro_requirement(self, mock_file):
+        ignored_rules = [
+            '\n# pazel-ignore\nload("//build-support/bazel/python3/deps:core.bzl", "py_library", "requirement")',
+        ]
+        output_build_file(
+            self.build_source,
+            ignored_rules,
+            self.output_extension,
+            self.custom_bazel_rules,
+            self.build_file_path,
+            self.requirement_load,
+            self.checks,
+            self.update,
+        )
+
+        expected_expression = """
+# pazel-ignore
+load("//build-support/bazel/python3/deps:core.bzl", "py_library", "requirement")
+
+py_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+)
+
+py_library(
+    name = "assume_role",
+    srcs = ["assume_role.py"],
+    deps = [
+        requirement("boto3"),
+        requirement("botocore"),
+    ],
+)
+"""
+        mock_file().write.assert_called_once_with(expected_expression)
+
+    @patch("pazel.output_build.open", new_callable=mock_open, read_data="")
+    def test_output_build_file_with_requirement_alias(self, mock_file):
+        """Test parse_enclosed_expression."""
+
+        ignored_rules = [
+            '\n# pazel-ignore\nload("@py3_airflow_deps//:requirements.bzl", airflow_requirement = "requirement")'
+        ]
+        output_build_file(
+            self.build_source,
+            ignored_rules,
+            self.output_extension,
+            self.custom_bazel_rules,
+            self.build_file_path,
+            self.requirement_load,
+            self.checks,
+            self.update,
+        )
+
+        expected_expression = """load("@py3_deps//:requirements.bzl", "requirement")
+
+# pazel-ignore
+load("@py3_airflow_deps//:requirements.bzl", airflow_requirement = "requirement")
+
+py_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+)
+
+py_library(
+    name = "assume_role",
+    srcs = ["assume_role.py"],
+    deps = [
+        requirement("boto3"),
+        requirement("botocore"),
+    ],
+)
+"""
+        mock_file().write.assert_called_once_with(expected_expression)
+
+    @patch("pazel.output_build.open", new_callable=mock_open, read_data="")
+    def test_output_build_file_for_default_requirement(self, mock_file):
+        ignored_rules = []
+        output_build_file(
+            self.build_source,
+            ignored_rules,
+            self.output_extension,
+            self.custom_bazel_rules,
+            self.build_file_path,
+            self.requirement_load,
+            self.checks,
+            self.update,
+        )
+
+        expected_expression = """load("@py3_deps//:requirements.bzl", "requirement")
+
+py_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+)
+
+py_library(
+    name = "assume_role",
+    srcs = ["assume_role.py"],
+    deps = [
+        requirement("boto3"),
+        requirement("botocore"),
+    ],
+)
+"""
+        mock_file().write.assert_called_once_with(expected_expression)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ DESCRIPTION = "Generate Bazel BUILD files for a Python project."
 
 setup(
     name='pazel',
-    version='0.3.6',
+    version='0.3.7',
     description=DESCRIPTION,
     packages=find_packages(exclude=('sample_app', 'sample_app.foo', 'sample_app.tests')),
     entry_points={


### PR DESCRIPTION
**Description**:
Add a condition to skip the pazel default requirement load for the bazel macros `requirement` function for each requirement dependency set.
Changes:
- Add a condition in [line 52](https://github.com/UrbanCompass/pazel/compare/master...UrbanCompass:pazel:dongyao.liu/TECH-12663-add-a-condition-for-default-requirement-load?expand=1#diff-eb6f0063f237265ce0081ddf26d027b4bccf1828cb0271be87ecd9fcc504f57dR53) that if any macro `requirement` function is loaded without alias pass the check.

**Context**
The pazel check each BUILD file of the monno repo python codes. If any bazel function `requirement` is used in the BUILD file(even we add the `pazel-ignore`, the pazel function [output_build_file](https://github.com/UrbanCompass/pazel/blob/master/pazel/output_build.py#L50) will add the default requirement load at the beginning of the BUILD file.
In the [design doc](https://docs.google.com/document/d/1V4Cm8YMWSgvdWSq2rpN068Y3mLzago0agwU8RLtPscA/edit?tab=t.0#heading=h.9abpjjbzwau4), we expect to use the macro bazel function `requirement` of each dependency set as the default one. If we add a load and apply in the BUILD file, for example
```
# pazel-ignore
load("//build-support/bazel/python3/deps:core.bzl", "py_library", "requirement")

py_library(
    name = "dd_apm",
    srcs = ["dd_apm.py"],
    deps = [
        requirement("ddtrace"),
    ],
)
```
The pazel refactors it to 
```
+load("@py3_deps//:requirements.bzl", "requirement")
# pazel-ignore
load("//build-support/bazel/python3/deps:core.bzl", "py_library", "requirement")

py_library(
    name = "dd_apm",
    srcs = ["dd_apm.py"],
    deps = [
        requirement("ddtrace"),
    ],
)
```
In this case, there will always 2 `requirement` load in the BUILD files where dependency macro bazel function `requirement` is used. It's difficult to understand why two requirements need to be loaded, and they are unable to determine which of the requirements is actually functioning.
Change the default [REQUIREMENT](https://github.com/UrbanCompass/urbancompass/blob/8764f6e515dda3f2a767df606a4db8bc77edc027/build-support/python3/.pazelrc#L485) is not feasible because all the legacy Python code we have relies on it. And it doesn't support multiple versions of default requirement for different dependency set.

**Local Test Result**
![image](https://github.com/user-attachments/assets/f06aa505-c946-46ed-a84a-deac1ae74e7b)


